### PR TITLE
Grunt setup

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -4,17 +4,79 @@ module.exports = function(grunt) {
 
     grunt.initConfig({
 
+      clean: ['build/'],
+
+      jshint: {
+           options: {
+               jshintrc: '.jshintrc',
+               ignores: ['node_modules/**']
+           },
+           source: {
+               files: {
+                   src: ['src/js/**/*.js']
+               }
+           }
+       },
+
         copy: {
             html: {
                 files: [
-                    { expand: true, cwd: 'src/', src: 'index.html', dest: 'build/' }
+                    {
+                      expand: true,
+                      cwd: 'src/',
+                      src: 'index.html',
+                      dest: 'build/'
+                    }
                 ]
-            }
+            },
+
+
+          vendorjs: {
+            files: [
+              {
+                expand: true,
+                cwd: 'node_modules/angular/',
+                src: ['angular.js'],
+                dest: 'build/js/'
+              }
+              // {
+              //   expand: true,
+              //   cwd: 'node_modules/angular-ui-router/release/',
+              //   src: ['angular-ui-router.js'],
+              //   dest: 'build.js'
+              // }
+            ]
+          }
+        },
+
+        concat: {
+          js: {
+            src: ['build/js/angular.js', 'src/js/hotelier.module.js', 'src/js/**/*.js'],
+            dest: 'build/js/app.js'
+          }
+        },
+
+        watch: {
+          html: {
+            files: ['src/index.html'],
+            tasks: ['copy:html']
+
+          },
+          js : {
+            files: ['src/js/**/*.js'],
+            tasks: ['test', 'concat']
+          }
         }
 
     });
 
     grunt.loadNpmTasks('grunt-contrib-copy');
+    grunt.loadNpmTasks('grunt-contrib-watch');
+    grunt.loadNpmTasks('grunt-contrib-clean');
+    grunt.loadNpmTasks('grunt-contrib-jshint');
+    grunt.loadNpmTasks('grunt-contrib-concat');
 
-    grunt.registerTask('default', [ 'copy' ]);
+
+    grunt.registerTask('test', ['jshint']);
+    grunt.registerTask('default', [ 'clean', 'test', 'copy', 'concat' ]);
 };

--- a/package.json
+++ b/package.json
@@ -16,9 +16,17 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "angular": "^1.5.9",
+    "angular-ui-router": "^0.3.2",
+    "http-server": "^0.9.0"
+  },
+  "devDependencies": {
     "grunt": "^1.0.1",
     "grunt-cli": "^1.2.0",
+    "grunt-contrib-clean": "^1.0.0",
+    "grunt-contrib-concat": "^1.0.1",
     "grunt-contrib-copy": "^1.0.0",
-    "http-server": "^0.9.0"
+    "grunt-contrib-jshint": "^1.1.0",
+    "grunt-contrib-watch": "^1.0.0"
   }
 }


### PR DESCRIPTION
Added necessary tasks to setup grunt in order to create a  build directory. The build directory has concatenated js files, and runs jshint. It copies the src index.html into the build directory. It cleans the build directory. Grunt task watch was setup to run build tasks when new changes are saved. 